### PR TITLE
Update readme.md with overwrite example.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,9 @@ console.log(dotaccess.get(obj, ['deep', 'trench']))
 // prints 44, spaces are allowed
 console.log(dotaccess.get(obj, 'deep.funky names'))
 
+// overwrite existing values
+dotaccess.set(obj, 'deep.funky names', 99, true)
+
 // can also set stuff
-dotaccess.set(obj, 'deep.funky names', 99)
+dotaccess.set(obj, 'deep.an even funkier_name', 'green')
 ```


### PR DESCRIPTION
Current docs don't make clear that to overwrite an existing value, user has to pass true as the fourth argument. This commit makes the difference between setting values that don't exist and overwriting existing values clearer.
