### PR TITLE
Support for unsetting (deleting) a property.

### DIFF
--- a/lib/dotaccess.js
+++ b/lib/dotaccess.js
@@ -1,4 +1,5 @@
 module.exports.set = set
+module.exports.unset = unset
 module.exports.get = get
 
 function parts(key) {
@@ -6,7 +7,7 @@ function parts(key) {
   return key.split('.')
 }
 
-function set(obj, key, value, overwrite) {
+function lookup(obj, key) {
   key = parts(key)
   var lastKey = key.pop()
   for (var i=0, l=key.length; i<l; i++) {
@@ -15,7 +16,21 @@ function set(obj, key, value, overwrite) {
     obj = obj[part]
     if (!obj) throw new Error('dotaccess: incompatible value in ' + part)
   }
-  if (overwrite || !(lastKey in obj)) obj[lastKey] = value
+  return [obj, lastKey];
+}
+
+function set(obj, key, value, overwrite) {
+  var objectAndKey = lookup(obj, key)
+    , obj = objectAndKey[0]
+    , key = objectAndKey[1];
+  if (overwrite || !(key in obj)) obj[key] = value
+}
+
+function unset(obj, key) {
+  var objectAndKey = lookup(obj, key)
+    , obj = objectAndKey[0]
+    , key = objectAndKey[1];
+  return delete obj[key];
 }
 
 function get(obj, key, def) {

--- a/test/dotaccess.js
+++ b/test/dotaccess.js
@@ -21,6 +21,41 @@ exports['get stuff'] = function() {
   assert.equal(46, dotaccess.get(obj, ['missing'], 46), 'Expect 46')
 }
 
+exports['unset stuff'] = function() {
+  var obj = {
+    answer: 42,
+    deep: {
+      trench: 43,
+      'funky names': 44,
+      'including a .': 45
+    }
+  }
+
+  assert(dotaccess.unset(obj, 'answer'))
+  assert.equal(undefined, dotaccess.get(obj, 'answer'), 'Expect unset - string')
+
+  assert(dotaccess.unset(obj, ['answer']))
+  assert.equal(undefined, dotaccess.get(obj, 'answer'), 'Expect unset - single element array')
+
+  assert(dotaccess.unset(obj, 'deep.trench'))
+  assert.equal(undefined, dotaccess.get(obj, 'deep.trench'), 'Expect unset - dot string')
+
+  assert(dotaccess.unset(obj, ['deep', 'trench']))
+  assert.equal(undefined, dotaccess.get(obj, ['deep', 'trench']), 'Expect unset - array')
+
+  assert(dotaccess.unset(obj, 'deep.funky names'))
+  assert.equal(undefined, dotaccess.get(obj, 'deep.funky names'), 'Expect unset - dot string funky names')
+
+  assert(dotaccess.unset(obj, ['deep', 'including a .']))
+  assert.equal(undefined, dotaccess.get(obj, ['deep', 'including a .']), 'Expect unset - array including dot')
+
+  assert(dotaccess.unset(obj, 'missing'))
+  assert.equal(undefined, dotaccess.get(obj, 'missing'), 'Expect unset - missing')
+
+  assert(dotaccess.unset(obj, ['missing']))
+  assert.equal(undefined, dotaccess.get(obj, ['missing']), 'Expect unset - missing')
+}
+
 exports['set stuff'] = function() {
   var obj = {
     existing: {


### PR DESCRIPTION
I've added support for the 'unset' operation. This deletes the specified property. In order to keep things DRY, I factored the lookup operation into its own function.
