### PR TITLE
Prevent dotaccess lib from throwing exception in browser.

### DIFF
--- a/lib/dotaccess.js
+++ b/lib/dotaccess.js
@@ -1,6 +1,12 @@
-module.exports.set = set
-module.exports.unset = unset
-module.exports.get = get
+var dotaccess = {
+  set: set,
+  unset: unset,
+  get: get
+}
+
+if (typeof module != 'undefined' && module.exports) {
+  module.exports = dotaccess;
+}
 
 function parts(key) {
   if (Array.isArray(key)) return key


### PR DESCRIPTION
When using RequireJS/AMD, dotaccess throws an exception due to `module` 
not being defined. This commit will prevent that kind of exception.
